### PR TITLE
Simplification of interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased](https://github.com/ParaConUK/monc_utils/tree/HEAD)
 
-[Full Changelog](https://github.com/ParaConUK/monc_utils/compare/v0.4.2...HEAD)
+[Full Changelog](https://github.com/ParaConUK/monc_utils/compare/v0.5.0...HEAD)
+
+## [v0.5.0](https://github.com/ParaConUK/monc_utils/tree/v0.4.3)
+
+Simplification of interface to remove ``ref_file``.
+
+[Full Changelog](https://github.com/ParaConUK/monc_utils/compare/v0.4.3...v0.5.0)
 
 ## [v0.4.3](https://github.com/ParaConUK/monc_utils/tree/v0.4.3)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ This will install as if into the standard library but using the cloned code
 which can be edited. Please commit code improvements and discuss merging with 
 the master branch with Peter Clark and other users.
 
+New in version 0.5.0
+1. Simplification of interface to remove ``ref_file``.
+2. Removal of possible confusion between ``th`` and ``theta`` etc..
+3. Some code rationalisation to improve sharing with um i/o.
+
 New in version 0.4.3
 1. Additions to difference_ops.py to 
 	- Add non-periodic xy support.

--- a/examples/test_datain.py
+++ b/examples/test_datain.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#%%
 """
 Created on Wed Jul 21 10:47:00 2021
 
 @author: xm904103
 """
 import os
+import sys
 
 import numpy as np
 import xarray as xr
@@ -18,6 +20,21 @@ import monc_utils
 import dask
 
 import matplotlib.pyplot as plt
+
+from pathlib import Path
+from loguru import logger
+
+logger.remove()
+logger.add(sys.stderr, 
+            format = "<c>{time:HH:mm:ss.SS}</c>"
+                  " | <level>{level:<8}</level>"
+                  " | <green>{function:<16}</green>"
+                  " : <green>{line:<4}</green> : {message}", 
+           colorize=True, 
+           level="INFO")
+    
+logger.enable("monc_utils")
+
 #from dask.diagnostics import Profiler, ResourceProfiler, CacheProfiler
 #from dask.diagnostics import ProgressBar
 
@@ -26,18 +43,18 @@ dask.config.set({"array.slicing.split_large_chunks": True})
 
 test_case = 0
 
-# onedrive = '"C:/Users/paclk/OneDrive - University of Reading/"
-#onedrive = "C:/Users/xm904103/OneDrive - University of Reading/"
-onedrive = "E:/Data/"
+# rootdir = '"C:/Users/paclk/rootdir - University of Reading/"
+#rootdir = "C:/Users/xm904103/rootdir - University of Reading/"
+rootdir = Path("F:")
 
 if test_case == 0:
     config_file = 'config_test_case_0.yaml'
-    indir = onedrive+'ug_project_data/'
-    odir = onedrive+'ug_project_data/'
+    indir = rootdir / 'traj_data/r_50m_60s_Monsoon3/'
+    odir = rootdir / 'traj_data/r_50m_60s_Monsoon3/test_out/'
 #    file = 'diagnostics_3d_ts_21600.nc'
 #    ref_file = 'diagnostics_ts_21600.nc'
-    file = 'diagnostics_3d_ts_23400.nc'
-    ref_file = 'diagnostics_ts_23400.nc'
+    file = 'diagnostics_3d_ts_16800.nc'
+    ref_file = 'diagnostics_ts_16800.nc'
     iz = 40
 #    iy = 95
     iy = 89
@@ -47,8 +64,8 @@ if test_case == 0:
 elif test_case == 1:
     config_file = 'config_test_case_1.yaml'
     #indir = '/storage/silver/wxproc/xm904103/'
-    indir = onedrive+'traj_data/CBL/'
-    odir = onedrive+'traj_data/CBL/'
+    indir = rootdir / 'CBL/'
+    odir = rootdir / 'CBL/'
     #odir = '/storage/silver/wxproc/xm904103/'
     file = 'diagnostics_3d_ts_13200.nc'
     ref_file = None
@@ -56,18 +73,20 @@ elif test_case == 1:
 
 options, update_config = mu.monc_utils_options(config_file)
 
+#%%
+
 options['aliases'] = {
     'th':['theta', 'potential_temperature'],
     'p':['pressure'],
     'tracer': ['tracer_rad2'],
     }
 options['save_all'] = 'no'
-odir = odir + 'test_datain/'
+# odir = odir / 'test_datain/'
 
-#dir = onedrive+'Git/python/monc_utils/test_data/BOMEX/'
-#odir = onedrive+'Git/python/monc_utils/test_data/BOMEX/'
+#dir = rootdir+'Git/python/monc_utils/test_data/BOMEX/'
+#odir = rootdir+'Git/python/monc_utils/test_data/BOMEX/'
 
-os.makedirs(odir, exist_ok = True)
+#os.makedirs(odir, exist_ok = True)
 
 #file = 'diagnostics_ts_18000.0.nc'
 #ref_file = 'diagnostics_ts_18000.0.nc'
@@ -106,7 +125,15 @@ os.makedirs(odir, exist_ok = True)
 var_list = [
 #     "saturation",
 #     "tracer",
-#     "th_L",
+    "thref",
+    "pref",
+    "theta_L",
+    "dbydz(theta_L)",
+#    "dbydz(teddy)",
+    "theta_v",
+    "dbydz(theta_v)",
+    "th",
+    "dbydz(th)",
 #     "q_vapour",
     "q_cloud_liquid_mass",
 #     "q_total",
@@ -138,7 +165,7 @@ var_list = [
 
 fname = 'test_datain'
 
-dataset = xr.open_dataset(indir+file)
+dataset = xr.open_dataset(indir / file)
 
 [itime, iix, iiy, iiz] = get_string_index(dataset.dims, ['time', 'x', 'y', 'z'])
 timevar = list(dataset.dims)[itime]
@@ -164,21 +191,31 @@ defn = 1
 #    dataset = xr.open_dataset(dir+file, chunks={timevar: defn,
 #                                                'z':'auto', 'zn':'auto'})
 
-dataset = xr.open_dataset(indir+file, chunks={timevar: defn,
+dataset = xr.open_dataset(indir / file, chunks={timevar: defn,
                                             xvar:nch, yvar:nch,
                                             'z':'auto', 'zn':'auto'})
 print(dataset)
 #    ref_dataset = Dataset(dir+ref_file, 'r')
 if ref_file is not None:
-    ref_dataset = xr.open_dataset(indir+ref_file)
+    ref_dataset = xr.open_dataset(indir / ref_file)
+    
+    ref_dataset = ref_dataset[['prefn', 'rho', 'rhon', 'thref', ]]
+    [itime] = get_string_index(ref_dataset.dims, ['time', ])
+    timevar = list(ref_dataset.dims)[itime]
+    
+    ref_dataset = ref_dataset.isel({timevar:0}).squeeze(drop=True).drop(timevar)
+    
+    dataset = xr.merge([dataset, ref_dataset])
 else:
     ref_dataset = None
+    
 
 for var_name in var_list:
     # op_var = di.get_data(dataset, ref_dataset, var_name,
     #                      options=options,
     #                      allow_none=True)
-    op_var = di.get_data_on_grid(dataset, ref_dataset, var_name,
+    op_var = di.get_data_on_grid(dataset, 
+                                 var_name,
                                  options=options)
     print(op_var)
     if op_var is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [
   { name='Peter Clark', email='p.clark@reading.ac.uk'},
   { name='Todd Jones', email='t.r.jones@reading.ac.uk'},
 ]
-license='MIT'
 description='python code to compute sub-filter quantities from MONC output.'
 readme = "README.md"
 requires-python = ">=3.9"
@@ -18,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-
+license='MIT'
 dependencies = [
     "numpy",
     "dask",
@@ -31,10 +30,9 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["src/"]
-#include = ["mynamespace.subpackage_a"]
 
 [project.urls]
-Homepage = "https://github.com/ReadingClouds/monc_utils"
-Issues = "https://github.com/ReadingClouds/monc_utils/issues"
+Homepage = "https://github.com/ParaConUK/monc_utils"
+Issues = "https://github.com/ParaConUK/monc_utils/issues"
 
 [tool.setuptools_scm]

--- a/src/monc_utils/data_utils/deformation.py
+++ b/src/monc_utils/data_utils/deformation.py
@@ -48,7 +48,7 @@ def deformation(source_dataset, ref_dataset, derived_dataset,
 
     @author: Peter Clark
     """
-    if 'deformation' in derived_dataset['ds']:
+    if derived_dataset is not None and 'deformation' in derived_dataset['ds']:
         deformation = derived_dataset['ds']['deformation']
         return deformation
 
@@ -128,7 +128,9 @@ def deformation(source_dataset, ref_dataset, derived_dataset,
 
     logger.info(f'Deformation: {defm}')
 
-    if options is not None and options['save_all'].lower() == 'yes':
+    if (derived_dataset is not None 
+        and options is not None 
+        and options['save_all'].lower()) == 'yes':
         defm = save_field(derived_dataset, defm)
 
     return defm

--- a/src/monc_utils/io/datain.py
+++ b/src/monc_utils/io/datain.py
@@ -4,7 +4,7 @@ Created on Mon Aug  2 11:01:11 2021.
 @author: Peter Clark
 """
 import numpy as np
-import xarray
+import xarray as xr
 from monc_utils.io.file_utils import (options_database,
                                       configure_model_resolution,
                                       )
@@ -19,20 +19,185 @@ import monc_utils
 import re
 from loguru import logger
 
+PGRID = [False,False,False]
+UGRID = [True,False,False]
+VGRID = [False,True,False]
+WGRID = [False,False,True]
+TGRID = PGRID
+BGRID = [True,True,False]
+
+"""
+Hierarchy 
+
+get_data_on_grid
+    get_and_transform
+        get_data
+            get_data
+            get_thref
+            get_pref
+            exner
+            get_derived_vars
+                get_data
+            get_derivative
+                get_data
+                d_by_dx_field_native
+                d_by_dy_field_native
+                d_by_dz_field_native
+            correct_grid_and_units
+        grid_conform
+    save_field
+    
+    
+
+"""
+
+def is_xy_periodic(field:xr.DataArray, 
+                   xy_periodic_def:bool=True) -> (xr.DataArray, bool):
+    """
+    Find if field is xy_periodic and set attribute in field.
+    Returns field.attrs['xy_periodic'] if available, otherwise default.
+
+    Parameters
+    ----------
+    field : xr.DataArray
+        Input MONC or UM field.
+    xy_periodic_def : bool, optional
+        DESCRIPTION. The default is True.
+
+    Returns
+    -------
+    field : xr.DataArray 
+        Input field with attrs['xy_periodic'] set..
+    xy_periodic : bool
+        True if xy_periodic.
+
+    """
+    
+    if 'xy_periodic' not in field.attrs:
+        xy_periodic = xy_periodic_def
+        field.attrs['xy_periodic'] = xy_periodic
+    else:
+        xy_periodic = field.attrs['xy_periodic']
+        
+    return field, xy_periodic
+
+def get_full_dim_name(field:xr.DataArray, dimname:str) -> str:
+    """
+    Find dimension name in input field that contains dimname.
+
+    Parameters
+    ----------
+    field : xr.DataArray
+        Any xr.DataArray
+    dimname : str
+        Part of possible dimname. Typical use is dimname='longitude' to match 
+        both 'longitude' and 'grid_longitude'.
+
+    Returns
+    -------
+    str or None
+        Corresponding dim if present.
+
+    """
+    
+    full_dim = [d for d in field.dims if dimname in d]
+    if full_dim : 
+        full_dim = full_dim[0]
+    else:
+        full_dim = None
+        
+    return full_dim
+
+def add_grid_attrs(field:xr.DataArray, coord_name:str, 
+                   xy_periodic:bool=True) -> xr.DataArray:
+    """
+    Add 'xy_periodic', drid spacing and domain size to field.attrs.
+
+    Parameters
+    ----------
+    field : xr.DataArray
+        Any xr.DataArray.
+    coord_name : str
+        dimension name or name part.
+    xy_periodic : bool, optional
+        xy_periodic or not. The default is True.
+
+    Returns
+    -------
+    field : xr.DataArray
+        Input field with modified attrs.
+
+    """
+    
+    if 'xy_periodic' in field.attrs:
+        xy_periodic = field.attrs['xy_periodic']
+    else:
+        if xy_periodic is None:
+            xy_periodic = True
+        field.attrs['xy_periodic'] = xy_periodic
+        
+    coord_name_full = get_full_dim_name(field, coord_name)
+    
+    if coord_name_full is None: return field
+
+    coord = field[coord_name_full]
+    
+    delta = coord.diff(dim=coord_name_full).min().item()
+    
+    if xy_periodic:
+        domain = coord.values[-1] - coord.values[0] + delta
+    else:
+        domain = coord.values[-1] - coord.values[0]
+    
+    field.attrs[f'd{coord_name[0]}'] = delta
+    field.attrs[f'L{coord_name[0]}'] = domain
+    
+    return field
+    
+def clean_coords(field:xr.DataArray, keep_coords=None) -> xr.DataArray:
+    """
+    Remove unwanted non-dimensional coords from field.
+    Will not remove 'elapsed_time'
+
+    Parameters
+    ----------
+    field : xr.DataArray
+        Any xr.DataArray.
+    keep_coords : list or None, optional
+        List of coords to keep. The default is None.
+
+    Returns
+    -------
+    field : xr.DataArray
+        Input DataArray cleaned of unwanted coords.
+
+    """
+    
+    if keep_coords is None: keep_coords = []
+
+    for c in field.coords:
+        if(c in field.dims 
+           or c == 'elapsed_time' 
+           or any([d in c for d in keep_coords]) ): continue
+        field = field.drop_vars(c)
+        
+    return field
+
 def correct_grid_and_units(var_name: str,
-                           vard: xarray.core.dataarray.DataArray,
-                           source_dataset: xarray.core.dataset.Dataset,
+                           vard: xr.core.dataarray.DataArray,
+                           source_dataset: xr.core.dataset.Dataset,
                            options: dict=None):
     """
     Correct input grid specification.
+    SPECIFIC TO MONC
 
     Parameters
     ----------
     var_name : str
         Name of variable to retrieve.
-    vard : xarray.core.dataarray.DataArray
+    vard : xr.core.dataarray.DataArray
         Input (at least 2D) data.
-    source_dataset : xarray.core.dataset.Dataset
+    source_dataset : xr.core.dataset.Dataset
         Source dataset for vard
     options : dict(optional - default=None)
         Options possibly used are 'dx' and 'dy'.
@@ -46,27 +211,43 @@ def correct_grid_and_units(var_name: str,
     #   Mapping of data locations on grid via logical triplet:
     #   logical[u-point,v-point,w-point]
     #          [False,  False,  False  ] --> (p,th,q)-point
-    var_properties = {"u":{"grid":[True,False,False],
+    var_properties = {"u":{"grid":UGRID,
                            "units":'m.s-1'},
-                      "v":{"grid":[False,True,False],
+                      "v":{"grid":VGRID,
                            "units":'m.s-1'},
-                      "w":{"grid":[False,False,True],
+                      "w":{"grid":WGRID,
                            "units":'m.s-1'},
-                      "th":{"grid":[False,False,False],
+                      "th":{"grid":TGRID,
                             "units":'K'},
-                      "p":{"grid":[False,False,False],
+                      "theta":{"grid":TGRID,
+                            "units":'K'},
+                      "thref":{"grid":TGRID,
+                            "units":'K'},
+                      "p":{"grid":PGRID,
                            "units":'Pa'},
-                      "q_vapour":{"grid":[False,False,False],
+                      "pressure":{"grid":PGRID,
+                           "units":'Pa'},
+                      "pref":{"grid":PGRID,
+                           "units":'Pa'},
+                      "q_vapour":{"grid":TGRID,
                                   "units":'kg/kg'},
-                      "q_cloud_liquid_mass":{"grid":[False,False,False],
+                      "q_cloud_liquid_mass":{"grid":TGRID,
                                              "units":'kg/kg'},
-                      "q_ice_mass":{"grid":[False,False,False],
+                      "q_ice_mass":{"grid":TGRID,
                                     "units":'kg/kg'},
+                      "u_b":{"grid":BGRID,
+                                             "units":'m.s-1'},
+                      "v_b":{"grid":BGRID,
+                                             "units":'m.s-1'},
                       }
 
     # Get model resolution values
-    dx, dy, options = configure_model_resolution(source_dataset,
-                                                 options=options)
+    if 'dx' not in vard.attrs or 'dx' not in vard.attrs:   
+        dx, dy, options = configure_model_resolution(source_dataset,
+                                                     options=options)
+    else:
+        dx = vard.attrs['dx']
+        dy = vard.attrs['dy']
 
     # Add correct x and y grids.
 
@@ -142,52 +323,14 @@ def correct_grid_and_units(var_name: str,
 
         if 'units' not in vard.attrs:        
             vard.attrs['units'] = ''
+            
+    for c in 'xy':        
+        field = add_grid_attrs(vard, c, xy_periodic=True)
 
     return vard
 
-def get_derived_vars(source_dataset, ref_dataset,
-                     var_name: str, derived_vars: dict, options: dict=None):
-    """
-    Get data from source_dataset and compute required variable.
-
-    Parameters
-    ----------
-    source_dataset : xarray Dataset
-        Input (at least 2D) data.
-    ref_dataset : xarray Dataset
-        Contains reference profiles. Can be None.
-    var_name : str
-        Name of variable to retrieve.
-    derived_vars : dict
-        Maps var_name to function name and argument list.
-    options : dict (optional - default=None)
-        Options. Options possibly used are 'dx' and 'dy'.
-
-    Returns
-    -------
-    vard : TYPE
-        DESCRIPTION.
-
-    """
-    dv = derived_vars[var_name]
-    args = []
-    for v in dv['vars']:
-        allow_none=False
-        if v[0] == '[':
-            allow_none=True
-            v = v[1:-1]
-        var = get_data(source_dataset, ref_dataset, v, options=options,
-                       allow_none=allow_none)
-        if var is not None:
-            args.append(var)
-        else:
-            logger.info(f'{v} not in dataset.')
-    vard = dv['func'](*args)
-    vard.name = var_name
-    vard.attrs['units'] = dv['units']
-    return vard
-    
-def get_data(source_dataset, ref_dataset, var_name: str,
+def get_data(source_dataset, 
+             var_name: str,
              options: dict=None,
              allow_none: bool=False) :
     """
@@ -214,8 +357,6 @@ def get_data(source_dataset, ref_dataset, var_name: str,
     ----------
     source_dataset : xarray Dataset
         Input (at least 2D) data.
-    ref_dataset :  xarray Dataset
-        Contains reference profiles. Can be None.
     var_name : str
         Name of variable to retrieve.
     options : dict (optional - default=None)
@@ -231,7 +372,12 @@ def get_data(source_dataset, ref_dataset, var_name: str,
     @author: Peter Clark
 
     """
+    
+    
     logger.info(f'Retrieving {var_name:s}.')
+    
+    vard = None
+    
     try:
         if var_name in source_dataset:
             vard = source_dataset[var_name]
@@ -253,87 +399,181 @@ def get_data(source_dataset, ref_dataset, var_name: str,
         # Change 'timeseries...' variable to 'time'
         [itime] = get_string_index(vard.dims, ['time'])
         if itime is not None:
-            vard = vard.rename({vard.dims[itime]: 'time'})
-
-        if var_name == 'th' :
-            thref = get_thref(ref_dataset,
-                              options=options)
-            vard += thref
-
-        if var_name == 'p' :
-            pref = get_pref(source_dataset, ref_dataset,
-                            options=options)
-            vard += pref
+            if vard.dims[itime] != 'time':
+                vard = vard.rename({vard.dims[itime]: 'time'})
 
     except KeyError:
-               
-        if var_name == 'thref' :
-            vard = get_thref(ref_dataset, options=options)
-        elif var_name == 'pref' :
-            vard = get_pref(source_dataset, ref_dataset, options=options)
-        elif var_name == 'piref' :
-            vard = th.exner(get_pref(source_dataset, ref_dataset,
-                                     options=options))
-        elif var_name == 'z' :
-            vard = ref_dataset.dims['z']
-        elif var_name == 'zn' :
-            vard = ref_dataset.dims['zn']
-
-        elif var_name in th.derived_vars:
-
-            vard = get_derived_vars(source_dataset, ref_dataset,
-                                    var_name, th.derived_vars,
-                                    options=options)
-            
-        else:
-            
-            deriv = re.compile(r'dbyd[xyz]\(*')
-            mo = deriv.match(var_name)
-            
-            if mo is not None:
         
-                target_var_name = var_name[mo.end():]
-                if target_var_name[-1] != ')':
-                    raise KeyError(f"Data {var_name:s} not in dataset.")
-                    
-                target_var_name = target_var_name[:-1]
+        match var_name:
+            case 'theta' :
+                thp = get_data(source_dataset, 'th', 
+                               options=options, allow_none=allow_none) 
+                thref = get_data(source_dataset, 'thref', 
+                               options=options, allow_none=allow_none)
+                vard = thp + thref
+                vard.name = 'theta'
+            case 'pressure' :
+                p = get_data(source_dataset, 'p', 
+                             options=options, allow_none=allow_none) 
+                pref = get_data(source_dataset, 'pref', 
+                             options=options, allow_none=allow_none)
+                vard = p + pref
+                vard.name = 'pressure'
+            case 'thref':
+                vard = get_thref(source_dataset, options=options)
+            case 'pref':
+                vard = get_pref(source_dataset, options=options)
+            case 'piref':
+                vard = th.exner(get_pref(source_dataset, options=options))
+            case 'z':
+                vard = source_dataset.dims['z']
+            case 'zn':
+                vard = source_dataset.dims['zn']
+            case _:
                 
-                target_var = get_data(source_dataset, 
-                                      ref_dataset, 
-                                      target_var_name,
-                                      options=options,
-                                      allow_none=allow_none)
-                
-                # No else required as match guaranteed above.
-                if var_name[4] == 'x':
-                    vard = do.d_by_dx_field_native(target_var)
-                elif var_name[4] == 'y':
-                    vard = do.d_by_dy_field_native(target_var)
-                elif var_name[4] == 'z':                    
-                    vard = do.d_by_dz_field_native(target_var )
-                    
-                # The following should be a null operation for derivatives.
+                if var_name in th.derived_vars:
 
-                vard = correct_grid_and_units(var_name, 
-                                              vard, 
-                                              source_dataset,
-                                              options=options)
+                    vard = get_derived_vars(source_dataset,
+                                            var_name, th.derived_vars,
+                                            options=options)
+            
+                elif var_name[:4] == 'dbyd':
                     
-                return vard
-                
-
-            else :
-                if allow_none:
-                    return None
+                    vard = get_derivative(source_dataset,
+                                         var_name,
+                                         options=options,
+                                         allow_none=allow_none) 
+                    
                 else:
-                    raise KeyError(f"Data {var_name:s} not in dataset.")
-                
-    vard = correct_grid_and_units(var_name, vard, source_dataset,
-                                  options=options)
+                    
+                    vard = None
+                        
+
+    if vard is None :
+        if allow_none:
+            return None
+        else:
+            raise KeyError(f"Data {var_name:s} not in dataset.")
+
+    else:                    
+        
+        vard = correct_grid_and_units(var_name, vard, source_dataset,
+                                      options=options)
 
     return vard
 
-def get_and_transform(source_dataset, ref_dataset, var_name,
+
+def get_derived_vars(source_dataset,
+                     var_name: str, derived_vars: dict, 
+                     options: dict=None,
+                     get_data_fn: callable=get_data):
+    """
+    Get data from source_dataset and compute required variable.
+
+    Parameters
+    ----------
+    source_dataset : xarray Dataset
+        Input (at least 2D) data.
+    var_name : str
+        Name of variable to retrieve.
+    derived_vars : dict
+        Maps var_name to function name and argument list.
+    options : dict (optional - default=None)
+        Options. Options possibly used are 'dx' and 'dy'.
+    get_data_fn: callable
+        Function used to 
+
+    Returns
+    -------
+    vard : TYPE
+        DESCRIPTION.
+
+    """
+    dv = derived_vars[var_name]
+    args = []
+    for v in dv['vars']:
+        allow_none=False
+        if v[0] == '[':
+            allow_none=True
+            v = v[1:-1]
+        var = get_data_fn(source_dataset, v, 
+                       options=options,
+                       allow_none=allow_none)
+        if var is not None:
+            args.append(var)
+        else:
+            logger.info(f'{v} not in dataset.')
+    vard = dv['func'](*args)
+    vard.name = var_name
+    vard.attrs['units'] = dv['units']
+    return vard
+
+def get_derivative(source_dataset,
+                   var_name: str,
+                   options: dict=None,
+                   allow_none: bool=False,
+                   get_data_fn: callable=get_data) :
+    """
+    Get data from source_dataset and compute required variable.
+
+    Parameters
+    ----------
+    source_dataset : xarray Dataset
+        Input (at least 2D) data.
+    var_name : str
+        Should be of form dbyds(variable) where variable is name of 
+        variable to retrieve and s=x or y or z. 
+    options : dict (optional - default=None)
+        Options. Options possibly used are 'dx' and 'dy'.
+    allow_none : bool (optional - default=False)
+        If True, return None if not found.
+
+    Returns
+    -------
+    vard : TYPE
+        DESCRIPTION.
+
+    """
+
+
+    deriv = re.compile(r'dbyd[xyz]\(*')
+    mo = deriv.match(var_name)
+    
+    if mo is None:
+        return None
+
+    target_var_name = var_name[mo.end():]
+    if target_var_name[-1] != ')':
+        raise KeyError(f"Data {var_name:s} not in dataset.")
+        
+    target_var_name = target_var_name[:-1]
+    
+    target_var = get_data_fn(source_dataset, 
+                             target_var_name,
+                             options=options,
+                             allow_none=allow_none)
+    
+    # No else required as match guaranteed above.
+    if var_name[4] == 'x':
+        vard = do.d_by_dx_field_native(target_var)
+    elif var_name[4] == 'y':
+        vard = do.d_by_dy_field_native(target_var)
+    elif var_name[4] == 'z':                    
+        vard = do.d_by_dz_field_native(target_var )
+        
+    # The following should be a null operation for derivatives.
+    
+    vard.attrs.update(target_var.attrs)
+
+    vard = correct_grid_and_units(var_name, 
+                                  vard, 
+                                  source_dataset,
+                                  options=options)
+    return vard
+
+    
+
+def get_and_transform(source_dataset, var_name,
                       options=None,
                       grid='p'):
     """
@@ -345,8 +585,6 @@ def get_and_transform(source_dataset, ref_dataset, var_name,
     ----------
     source_dataset : xarray Dataset
         Input (at least 2D) data.
-    ref_dataset : xarray Dataset
-        Contains reference profiles. Can be None.
     var_name : str
         Name of variable to retrieve.
     options : dict (optional - default=None)
@@ -362,7 +600,7 @@ def get_and_transform(source_dataset, ref_dataset, var_name,
     @author: Peter Clark
 
     """
-    var = get_data(source_dataset, ref_dataset, var_name, options=options)
+    var = get_data(source_dataset, var_name, options=options)
     if "z" in source_dataset.dims:
         z_w = source_dataset["z"].rename({'z':'z_w'})
     elif "z_w" in source_dataset.dims:
@@ -385,7 +623,7 @@ def get_and_transform(source_dataset, ref_dataset, var_name,
 
     return var
 
-def get_data_on_grid(source_dataset, ref_dataset, var_name,
+def get_data_on_grid(source_dataset, var_name,
                      derived_dataset=None,
                      options=None,
                      grid='p') :
@@ -403,8 +641,6 @@ def get_data_on_grid(source_dataset, ref_dataset, var_name,
     ----------
     source_dataset : xarray Dataset
         Input (at least 2D) data.
-    ref_dataset : xarray Dataset
-        Contains reference profiles. Can be None.
     var_name : str
         Name of variable to retrieve.
     derived_dataset : dict, optional
@@ -449,7 +685,7 @@ def get_data_on_grid(source_dataset, ref_dataset, var_name,
             logger.info(f'Retrieved {op_var_name:s} from derived dataset.')
             return op_var
 
-    op_var = get_and_transform(source_dataset, ref_dataset,
+    op_var = get_and_transform(source_dataset, 
                                var_name, options=options, grid=grid)
     op_var.name = op_var_name
 
@@ -461,7 +697,7 @@ def get_data_on_grid(source_dataset, ref_dataset, var_name,
 
     return op_var
 
-def get_pref(source_dataset, ref_dataset,  options=None):
+def get_pref(source_dataset, options=None):
     """
     Get reference pressure profile for source_dataset.
 
@@ -482,7 +718,8 @@ def get_pref(source_dataset, ref_dataset,  options=None):
     pref
 
     """
-    if ref_dataset is None:
+         
+    if 'prefn'  not in source_dataset.data_vars:
         od = options_database(source_dataset)
         if od is not None:
             p_surf = float(od['surface_pressure'])
@@ -498,27 +735,26 @@ def get_pref(source_dataset, ref_dataset,  options=None):
         piref0 = (p_surf/thc.p_ref_theta)**thc.kappa
         piref = piref0 - (thc.g/(thc.cp_air * thref)) * zn
         pref = thc.p_ref_theta * piref**thc.rk
-#        pref = xarray.DataArray(pref, dims=['time'], coords={'time':[0.0]})
-
-#                logger.info('pref', pref)
     else:
-        pref = ref_dataset['prefn']
+        pref = source_dataset['prefn']
         [itime] = get_string_index(pref.dims, ['time'])
         if itime is not None:
-            tvar = pref.dims[itime]
+            tvar = list(pref.dims[itime])
             pref = pref.isel({tvar:0}).squeeze(drop=True).drop(tvar)
+        pref = correct_grid_and_units('pref', pref, source_dataset,
+                                      options=options)
             
     pref.attrs['units'] = 'Pa'
 
     return pref
 
-def get_thref(ref_dataset, options=None):
+def get_thref(source_dataset, options=None):
     """
     Get thref profile from ref_dataset.
 
     Parameters
     ----------
-    ref_dataset : netCDF4 file or None
+    source_dataset : netCDF4 file or None
         MONC output file containing pref
     options : dict
         Options. Options possibly used are th_ref.
@@ -529,19 +765,22 @@ def get_thref(ref_dataset, options=None):
         Reference theta constant or profile
 
     """
-    if ref_dataset is None:
+
+    if source_dataset is None or 'thref'  not in source_dataset.data_vars:
         if options is None:
             thref = 300.0
         else:
             thref = options['th_ref']
-        thref = xarray.DataArray(thref, dims=['time'], coords={'time':[0.0]})
+        thref = xr.DataArray(thref, dims=['time'], coords={'time':[0.0]})
         
     else:
-        thref = ref_dataset['thref']
+        thref = source_dataset['thref']
         [itime] = get_string_index(thref.dims, ['time'])
         if itime is not None:
             tvar = thref.dims[itime]
             thref = thref.isel({tvar:0}).squeeze(drop=True).drop(tvar)
+        thref = correct_grid_and_units('thref', thref, source_dataset,
+                                        options=options)
             
     thref.attrs['units'] = 'K'
 

--- a/src/monc_utils/io_um/datain.py
+++ b/src/monc_utils/io_um/datain.py
@@ -8,14 +8,43 @@ import xarray as xr
 import typing
 import datetime
 from monc_utils.data_utils.string_utils import get_string_index
+from monc_utils.io.datain import (is_xy_periodic,
+                                  add_grid_attrs,
+                                  clean_coords,
+                                  get_full_dim_name,
+                                  correct_grid_and_units, 
+                                  get_derived_vars,
+                                  get_derivative)
+
 from monc_utils.io.dataout import save_field
 from monc_utils.data_utils.dask_utils import re_chunk
 
 import monc_utils.data_utils.difference_ops as do
 import monc_utils.thermodynamics.thermodynamics as th
 import monc_utils
-import re
+
 from loguru import logger
+
+"""
+Hierarchy
+
+get_um_data_on_grid
+    get_um_and_transform
+        get_um_data
+            get_um_field
+                coords_to_cartesian
+                coords_to_latlon
+                clean_coords
+            get_derived_vars
+                get_um_data
+            get_derivative
+                get_data
+                d_by_dx_field_native
+                d_by_dy_field_native
+                d_by_dz_field_native
+            correct_grid_and_units
+
+"""
 
 um_datain_options = {'cartesian':False,
                      'xy_periodic':False,
@@ -27,6 +56,7 @@ stash_map = { 'u'                  : 'm01s00i002',
               'v'                  : 'm01s00i003',
               'w'                  : 'm01s00i150',
               'th'                 : 'm01s00i004',
+              'theta'              : 'm01s00i004',
               'air_potential_temperature': 'm01s00i004',
               'surface_altitude'   : 'm01s00i033',
               'q_vapour'           : 'm01s00i010', 
@@ -59,6 +89,7 @@ stash_map = { 'u'                  : 'm01s00i002',
               'air_temperature'    : 'm01s16i004',
             }
 
+
 PGRID = [False,False,False]
 UGRID = [True,False,False]
 VGRID = [False,True,False]
@@ -67,39 +98,17 @@ TGRID = WGRID
 BGRID = [True,True,False]
 
 
-def set_um_datain_options(opts):
+def set_um_datain_options(opts:dict):
     global um_datain_options
     um_datain_options.update(opts)
     logger.info(f'{um_datain_options=}')
     return
     
-def set_um_stashmap(stash_map_update):
+def set_um_stashmap(stash_map_update:dict):
     global stash_map
     stash_map.update(stash_map_update)
     logger.info('Updated stash_map.')
     return
-    
-    
-def clean_dims(field, keep_dims=None):
-    
-    if keep_dims is None: keep_dims = []
-
-    for c in field.coords:
-        if(c in field.dims or c == 'elapsed_time' 
-           or any([d in c for d in keep_dims]) ): continue
-        field = field.drop_vars(c)
-        
-    return field
-
-def get_coord(field, dimname):
-    
-    full_dim = [d for d in field.dims if dimname in d]
-    if len(full_dim) > 0 : 
-        full_dim = full_dim[0]
-    else:
-        full_dim = None
-        
-    return full_dim
 
 def coords_to_latlon(field:xr.DataArray, offsets:typing.Optional[dict]=None):
     """
@@ -132,7 +141,6 @@ def coords_to_latlon(field:xr.DataArray, offsets:typing.Optional[dict]=None):
         DESCRIPTION.
 
     """
-    
     var_properties = {"u":{"grid":UGRID,
                            "units":'m.s-1'},
                       "v":{"grid":VGRID,
@@ -141,7 +149,11 @@ def coords_to_latlon(field:xr.DataArray, offsets:typing.Optional[dict]=None):
                            "units":'m.s-1'},
                       "th":{"grid":TGRID,
                             "units":'K'},
+                      "theta":{"grid":TGRID,
+                            "units":'K'},
                       "p":{"grid":PGRID,
+                           "units":'Pa'},
+                      "pressure":{"grid":PGRID,
                            "units":'Pa'},
                       "q_vapour":{"grid":TGRID,
                                   "units":'kg/kg'},
@@ -150,11 +162,17 @@ def coords_to_latlon(field:xr.DataArray, offsets:typing.Optional[dict]=None):
                       "q_ice_mass":{"grid":TGRID,
                                     "units":'kg/kg'},
                       "u_b":{"grid":BGRID,
-                                             "units":'m.s-1'},
+                             "units":'m.s-1'},
                       "v_b":{"grid":BGRID,
-                                             "units":'m.s-1'},
+                             "units":'m.s-1'},
                       }
-        
+    
+    field.attrs['cartesian'] = False
+    
+    field, xy_periodic = is_xy_periodic(field, 
+                           xy_periodic_def=
+                           um_datain_options.get('xy_periodic', False))    
+       
     if offsets is None:
         offsets={'x':0, 'y':0, 'z':0}
     
@@ -169,7 +187,7 @@ def coords_to_latlon(field:xr.DataArray, offsets:typing.Optional[dict]=None):
             zip(['longitude','latitude','model_level'],
                 ['u', 'v', 'w'])):
         
-        c = get_coord(field, coord)
+        c = get_full_dim_name(field, coord)
         
         if c is None: continue
             
@@ -190,20 +208,35 @@ def coords_to_latlon(field:xr.DataArray, offsets:typing.Optional[dict]=None):
             coord_vals = base_coord_vals + offsets['xyz'[i]] + [0.0, 0.0, -0.5][i]           
             new_coord = 'xyz'[i] + '_p'
             
+            
         field = field.assign_coords({new_coord: (c, coord_vals)})
         field = field.rename({c:new_name})
         swap_map[new_name] = new_coord
 
     field = field.swap_dims(swap_map)
-
+    
+    for c in 'xy':        
+        field = add_grid_attrs(field, c, xy_periodic=xy_periodic)
 
     if 'units' not in field.attrs:        
         field.attrs['units'] = in_properties['units']
-            
+                  
     return field
     
 def coords_to_cartesian(field):
-    
+    """
+    SPECIFIC TO UM
+
+    Parameters
+    ----------
+    field : TYPE
+        DESCRIPTION.
+
+    Returns
+    -------
+    None.
+
+    """    
     def _adjust_cyclic_data_order(field, dimname, vname):
         logger.info(f"Rolling {vname} data")
         field = field.roll({dimname:-1}, roll_coords=True) 
@@ -211,7 +244,12 @@ def coords_to_cartesian(field):
         c[-1] = c[-2]*2 - c[-3]
         field = field.assign_coords({old_coord:c})
         return field
-        
+    
+    field.attrs['cartesian'] = True
+    field, xy_periodic = is_xy_periodic(field, 
+                           xy_periodic_def=
+                           um_datain_options.get('xy_periodic', True))
+    
     for new_coord, old_coord in zip(('x', 'y', 'z', 'time'), 
                                     get_um_coords(field)):
         
@@ -219,9 +257,20 @@ def coords_to_cartesian(field):
     
         if new_coord == 'z':
             
-            vert_dim = [d for d in field.dims if 'lev_eta' in d][0]
-            if 'rho' in vert_dim: new_coord_full = 'z_p'
-            else: new_coord_full = 'z_w'
+            vert_dim = get_full_dim_name(field, 'lev_eta')
+            if vert_dim is not None:
+                if 'rho' in vert_dim: 
+                    new_coord_full = 'z_p'
+                else: 
+                    new_coord_full = 'z_w'
+            else: 
+                vert_dim = get_full_dim_name(field, 'level_number')
+                if vert_dim is not None:
+                    if 'w' in vert_dim: 
+                        new_coord_full = 'z_w'
+                    else: 
+                        new_coord_full = 'z_p'
+                
             
             field = field.rename({old_coord:new_coord_full})
             field = field.swap_dims({vert_dim:new_coord_full})
@@ -254,6 +303,11 @@ def coords_to_cartesian(field):
                     {new_coord_full: (old_coord, new_coord_values)}) 
                    
                 field = field.swap_dims({old_coord:new_coord_full})
+                
+                field = add_grid_attrs(field, 
+                                       new_coord_full, 
+                                       xy_periodic=xy_periodic)
+                
             else:
                 field = field.rename({old_coord:new_coord_full})          
             
@@ -267,6 +321,7 @@ def coords_to_cartesian(field):
 
         if 'bounds' in field[new_coord_full].attrs:
             field[new_coord_full].attrs.pop('bounds')
+            
             
     return field
     
@@ -293,7 +348,7 @@ def get_um_field(ds, stash:str=None, name:str=None):
     
     cartesian = um_datain_options.get('cartesian', True)  
     
-    keep_dims = um_datain_options.get('keep_dims', [])
+    keep_coords = um_datain_options.get('keep_coords', [])
     
     if name is None:
         if stash is None:
@@ -309,56 +364,12 @@ def get_um_field(ds, stash:str=None, name:str=None):
                 
     if cartesian:
         field = coords_to_cartesian(field)
-        field.attrs['xy_periodic'] = True
-        field.attrs['cartesian'] = True
     else:
         field = coords_to_latlon(field)
-        field.attrs['xy_periodic'] = False
-        field.attrs['cartesian'] = False
                  
-    field = clean_dims(field, keep_dims=keep_dims)
+    field = clean_coords(field, keep_coords=keep_coords)
     
     return field
-
-def get_derived_um_vars(source_dataset, 
-                        var_name: str, derived_vars: dict, options: dict=None):
-    """
-    Get data from source_dataset and compute required variable.
-
-    Parameters
-    ----------
-    source_dataset : xarray.Dataset
-        Input (at least 2D) data.
-    var_name : str
-        Name of variable to retrieve.
-    derived_vars : dict
-        Maps var_name to function name and argument list.
-    options : dict (optional - default=None)
-        Options. Options possibly used are 'dx' and 'dy'.
-
-    Returns
-    -------
-    vard : xarray.core.dataarray.DataArray
-        Required data.
-
-    """
-    dv = derived_vars[var_name]
-    args = []
-    for v in dv['vars']:
-        allow_none=False
-        if v[0] == '[':
-            allow_none=True
-            v = v[1:-1]
-        var = get_um_data(source_dataset, v, options=options,
-                          allow_none=allow_none)
-        if var is not None:
-            args.append(var)
-        else:
-            logger.info(f'{v} not in dataset.')
-    vard = dv['func'](*args)
-    vard.name = var_name
-    vard.attrs['units'] = dv['units']
-    return vard
     
 def get_um_data(source_dataset,
                 var_name: str,
@@ -440,9 +451,10 @@ def get_um_data(source_dataset,
     except KeyError:
                
         if var_name == 'piref':
-            vard = get_derived_um_vars(source_dataset,
+            vard = get_derived_vars(source_dataset,
                                     'exner', th.derived_vars,
-                                    options=options)
+                                    options=options,
+                                    get_data_fn=get_um_data)
             vard = get_mean(vard)
             vard.name = var_name  
             
@@ -453,46 +465,35 @@ def get_um_data(source_dataset,
                                     
         elif var_name in th.derived_vars:
 
-            vard = get_derived_um_vars(source_dataset, 
+            vard = get_derived_vars(source_dataset, 
                                        var_name, 
                                        th.derived_vars,
-                                       options=options)
-            
-        else:
-            
-            deriv = re.compile(r'dbyd[xyz]\(*')
-            mo = deriv.match(var_name)
-            
-            if mo is not None:
-        
-                target_var_name = var_name[mo.end():]
-                if target_var_name[-1] != ')':
-                    raise KeyError(f"Data {var_name:s} not in dataset.")
+                                       options=options,
+                                       get_data_fn=get_um_data)
+        elif var_name[:4] == 'dbyd':
                     
-                target_var_name = target_var_name[:-1]
-                
-                target_var = get_um_data(source_dataset, 
-                                         target_var_name,
-                                         options=options,
-                                         allow_none=allow_none)
-                
-                # No else required as match guaranteed above.
-                if var_name[4] == 'x':
-                    vard = do.d_by_dx_field_native(target_var)
-                elif var_name[4] == 'y':
-                    vard = do.d_by_dy_field_native(target_var)
-                elif var_name[4] == 'z':                    
-                    vard = do.d_by_dz_field_native(target_var )
-                                        
-                return vard
+            vard = get_derivative(source_dataset,
+                                  var_name,
+                                  options=options,
+                                  allow_none=allow_none,
+                                  get_data_fn=get_um_data) 
                 
 
-            else :
-                if allow_none:
-                    return None
-                else:
-                    raise KeyError(f"Data {var_name:s} not in dataset.")
-                
+        else :
+            
+            vard = None
+
+    if vard is None :
+        if allow_none:
+            return None
+        else:
+            raise KeyError(f"Data {var_name:s} not in dataset.")
+
+    else:                    
+        
+        vard = correct_grid_and_units(var_name, vard, source_dataset,
+                                      options=options)
+
     return vard
 
 def get_um_and_transform(source_dataset, var_name,
@@ -531,7 +532,7 @@ def get_um_and_transform(source_dataset, var_name,
         else:
             raise KeyError(f"Cannot find {c} in dataset.")
         c.name = c_new
-        return clean_dims(c)
+        return clean_coords(c)
         
     
     var = get_um_data(source_dataset, var_name, options=options)

--- a/src/monc_utils/thermodynamics/thermodynamics.py
+++ b/src/monc_utils/thermodynamics/thermodynamics.py
@@ -615,7 +615,7 @@ def equiv_potential_temperature_approx(T, p, q):
     e = q_p_to_e(q, p)
     m = q_to_mix(q)
     T_LCL = t_lcl_e(T, e)
-    theta= moist_potential_temperature(T , p, m)
+    theta= moist_potential_temperature(T, p, m)
 
     theta_e = theta * \
       np.exp((C1/T_LCL-C2) * m * (1 + C3 * m) )
@@ -803,7 +803,7 @@ def sat_unsat_wet_bulb_potential_temperature(T, p, q,
         
     if pp is None: pp = p.isel(z_p=sl).mean('z_p')
 
-    if TDp is None: TDp =  dewpoint(Tp, pp, q.isel(z_p=sl).mean('z_p'))
+    if TDp is None: TDp =  dewpoint(Tp, p, q.isel(z_p=sl).mean('z_p'))
     
     T_LCL = t_lcl_td(Tp, TDp)
     
@@ -1508,11 +1508,11 @@ derived_vars = {
     #      'func': ,
     #      'units': ''},
     'rh_ice':
-        {'vars': ('T', 'p', 'q_vapour'),
+        {'vars': ('T', 'pressure', 'q_vapour'),
          'func': rh_ice,
          'units': ''},
     'rh':
-        {'vars': ('T', 'p', 'q_vapour'),
+        {'vars': ('T', 'pressure', 'q_vapour'),
           'func': rh,
           'units': ''},
     'esat':
@@ -1524,19 +1524,19 @@ derived_vars = {
          'func': esat_ice,
          'units': 'Pa'},
     'exner':
-        {'vars': ('p',),
+        {'vars': ('pressure',),
          'func': exner,
          'units': ''},
     'T':
-        {'vars': ('th', 'p'),
+        {'vars': ('theta', 'pressure'),
          'func': temperature,
          'units': 'K'},
 #    'th':
-#        {'vars': ('T', 'p'),
+#        {'vars': ('T', 'pressure'),
 #         'func': potential_temperature,
 #         'units': 'K'},
-    'th_m':
-        {'vars': ('T', 'p', 'm_vapour'),
+    'theta_m':
+        {'vars': ('T', 'pressure', 'm_vapour'),
          'func': moist_potential_temperature,
          'units': 'K'},
     'm_vapour':
@@ -1572,47 +1572,47 @@ derived_vars = {
          'func': t_lcl_rh,
          'units': ''},
     'T_dew':
-        {'vars': ('T', 'p', 'q'),
+        {'vars': ('T', 'pressure', 'q_vapour'),
          'func': dewpoint,
          'units': 'K'},
     'qsat':
-        {'vars': ('T', 'p'),
+        {'vars': ('T', 'pressure'),
          'func': qsat,
          'units': ''},
     'alpha':
-        {'vars': ('T', 'p'),
+        {'vars': ('T', 'pressure'),
          'func': dqsatbydT,
          'units': r'K$^{-1}$'},
     'T_w':
-        {'vars': ('T', 'p', 'q_vapour'),
+        {'vars': ('T', 'pressure', 'q_vapour'),
          'func': wet_bulb_temperature,
          'units': 'K'},
-    'th_w':
-        {'vars': ('T', 'p', 'q_vapour'),
+    'theta_w':
+        {'vars': ('T', 'pressure', 'q_vapour'),
          'func': wet_bulb_potential_temperature,
          'units': 'K'},
-    'th_s':
-        {'vars': ('T', 'p'),
+    'theta_s':
+        {'vars': ('T', 'pressure'),
          'func': sat_wet_bulb_potential_temperature,
          'units': 'K'},
-    'th_sw':
-        {'vars': ('T', 'p', 'q_vapour'),
+    'theta_sw':
+        {'vars': ('T', 'pressure', 'q_vapour'),
          'func': sat_unsat_wet_bulb_potential_temperature,
          'units': 'K'},
-    'th_e':
-        {'vars': ('T', 'p', 'q_vapour'),
+    'theta_e':
+        {'vars': ('T', 'pressure', 'q_vapour'),
          'func': equiv_potential_temperature,
          'units': 'K'},
-    'th_L':
-        {'vars': ('th','q_cloud_liquid_mass','piref'),
+    'theta_L':
+        {'vars': ('theta','q_cloud_liquid_mass','piref'),
          'func': liquid_water_potential_temperature,
          'units': 'K'},
-    'th_v':
-        {'vars': ('th', 'q_vapour','q_cloud_liquid_mass'),
+    'theta_v':
+        {'vars': ('theta', 'q_vapour','q_cloud_liquid_mass'),
          'func': virtual_potential_temperature,
         'units': 'K'},
-    'th_v_monc':
-        {'vars': ('th','thref','q_vapour','q_cloud_liquid_mass'),
+    'theta_v_monc':
+        {'vars': ('theta','thref','q_vapour','q_cloud_liquid_mass'),
          'func': virtual_potential_temperature_monc,
         'units': 'K'},
     'q_total':
@@ -1620,39 +1620,39 @@ derived_vars = {
          'func': q_total,
          'units': 'kg/kg'},
     'buoyancy':
-        {'vars': ('th_v',),
+        {'vars': ('theta_v',),
          'func': buoyancy,
          'units': r'm s$^{-2}$'},
     'buoyancy_monc':
-        {'vars': ('th_v', 'thref',),
+        {'vars': ('theta_v', 'thref',),
          'func': buoyancy_monc,
          'units': r'm s$^{-2}$'},
     'buoyancy_moist':
-        {'vars': ('th','thref','p','q_vapour','q_cloud_liquid_mass'),
+        {'vars': ('theta','thref','pressure','q_vapour','q_cloud_liquid_mass'),
          'func': buoyancy_moist,
          'units': r'm s$^{-2}$'},
     'moist_dbdz':
-        {'vars':('th', 'thref', 'pref', 'q_vapour', 'q_cloud_liquid_mass',
+        {'vars':('theta', 'thref', 'pref', 'q_vapour', 'q_cloud_liquid_mass',
                  'z', 'zn') ,
           'func': moist_dbdz,
           'units': r's$^{-2}$'},
     'dmoist_bdz':
-        {'vars':('th', 'thref', 'p', 'q_vapour', 'q_cloud_liquid_mass',
+        {'vars':('theta', 'thref', 'pressure', 'q_vapour', 'q_cloud_liquid_mass',
                  'z', 'zn') ,
           'func': dmoist_bdz,
           'units': r's$^{-2}$'},
     'dbdz':
-        {'vars': ('th', 'p', 'q_vapour', 'q_cloud_liquid_mass',
+        {'vars': ('theta', 'pressure', 'q_vapour', 'q_cloud_liquid_mass',
                  'z', 'zn'),
          'func': dbdz,
          'units': r's$^{-2}$'},
     'dbdz_monc':
-        {'vars': ('th', 'thref', 'p', 'q_vapour', 'q_cloud_liquid_mass',
+        {'vars': ('theta', 'thref', 'pressure', 'q_vapour', 'q_cloud_liquid_mass',
                  'z', 'zn'),
          'func': dbdz_monc,
          'units': r's$^{-2}$'},
     'saturation':
-        {'vars': ('th','thref','pref', 'q_vapour','q_cloud_liquid_mass'),
+        {'vars': ('theta','thref','pref', 'q_vapour','q_cloud_liquid_mass'),
          'func': saturation,
         'units': 'kg/kg'},
     'cloud_fraction':


### PR DESCRIPTION
Removes requirement for ref_file - assumes reference profiles are in the input dataset. See examples for how to achieve this.

As a result, standard variable names changed to distinguish `theta` from the `th`  etc..